### PR TITLE
Wake on motion and I2c driver fix

### DIFF
--- a/qwiic_icm20948.py
+++ b/qwiic_icm20948.py
@@ -399,7 +399,7 @@ class QwiicIcm20948(object):
 			:rtype: bool
 
 		"""
-		return qwiic_i2c.isDeviceConnected(self.address)
+		return self._i2c.isDeviceConnected(self.address)
 
 	connected = property(isConnected)
 


### PR DESCRIPTION
- Updated isConnected so that it uses the specified i2c driver when one is provided instead of always using the default i2c driver.
- Added support for "wake on motion" by adding readAndClearInterrupts, enableWOMInterrupt, and setWakeOnMotionThreshold methods.